### PR TITLE
remove all dependencies from the snips binary

### DIFF
--- a/deps/install_deps.sh
+++ b/deps/install_deps.sh
@@ -3,25 +3,11 @@
 set -e
 
 required_packages=(
-  libportaudio2_19.6.0-1_armhf.deb
-  python-ply_3.9-1_all.deb
-  python-pycparser_2.17-2_all.deb
-  python-cffi_1.9.1-2_all.deb
-  libgfortran3_6.3.0-18+rpi1+deb9u1_armhf.deb
-  libblas-common_3.7.0-2_armhf.deb
-  libatlas3-base_3.10.3-1-snips_armhf.deb
-  libblas3_3.7.0-2_armhf.deb
-  python-soundfile_0.8.1-2_all.deb
-  liblapack3_3.7.0-2_armhf.deb
   libttspico-data_1.0+git20130326-5_all.deb
   libttspico0_1.0+git20130326-5_armhf.deb
   libttspico-utils_1.0+git20130326-5_armhf.deb
-  python-numpy_1.1.12.1-3_armhf.deb
-  python-pyaudio_0.2.11-1_armhf.deb
-  libwebsockets8_2.0.3-2+b1~rpt1_armhf.deb
-  mosquitto_1.4.10-3+deb9u4_armhf.deb
   snips-platform-common_0.63.2_armhf.deb
-  snips-kaldi-atlas_0.24.2_armhf.deb
+  snips-kaldi-openblas_0.24.2~1_armhf.deb
   snips-asr_0.63.2_armhf.deb
   snips-audio-server_0.63.2_armhf.deb
   snips-dialogue_0.63.2_armhf.deb
@@ -31,6 +17,15 @@ required_packages=(
   snips-platform-voice_0.63.2_armhf.deb
   snips-tts_0.63.2_armhf.deb
   snips-watch_0.63.2_armhf.deb
+)
+
+required_packages_common=(
+  libwebsockets8
+  mosquitto
+  libportaudio2
+  python-soundfile
+  python-numpy
+  python-pyaudio
 )
 
 check_pkg() {
@@ -46,6 +41,11 @@ install() {
 
 	unzip -o dependencies.zip -d .
 	sudo unzip -o assistant_proj_heysnips.zip -d /usr/share/snips
+
+        for pkg in ${required_packages_common[@]}; do
+                sudo apt-get install -y "$pkg"
+        done
+
 	for pkg in ${required_packages[@]}; do
     		if ! check_pkg "$pkg"; then
 	        	sudo dpkg -i "$pkg"
@@ -72,6 +72,10 @@ uninstall() {
      	    	pkg_="$(cut -d'_' -f1 <<<"$pkg")"
 		sudo dpkg --purge --force-depends "$pkg_"
         done
+        for pkg in ${required_packages_common[@]}; do
+                sudo apt-get purge -y "$pkg"
+        done
+
 	sudo rm -rf /usr/share/snips/
 	rm setup_complete
         echo "Uninstall complete"


### PR DESCRIPTION
all the deb packages in the zip will now run on strecth and buster without any additional dependancies, no need for gfortran or liblapack ..

```
required_packages=(
  libttspico-data_1.0+git20130326-5_all.deb
  libttspico0_1.0+git20130326-5_armhf.deb
  libttspico-utils_1.0+git20130326-5_armhf.deb
  snips-platform-common_0.63.2_armhf.deb
  snips-kaldi-openblas_0.24.2~1_armhf.deb
  snips-asr_0.63.2_armhf.deb
  snips-audio-server_0.63.2_armhf.deb
  snips-dialogue_0.63.2_armhf.deb
  snips-hotword_0.63.2_armhf.deb
  snips-injection_0.63.2_armhf.deb
  snips-nlu_0.63.2_armhf.deb
  snips-platform-voice_0.63.2_armhf.deb
  snips-tts_0.63.2_armhf.deb
  snips-watch_0.63.2_armhf.deb
)
```

the only remaining components are for mosquitto and the python action code , the latter are platform specifics and should be pulled from the debian repo

cf :
```
required_packages_common=(
  libwebsockets8
  mosquitto
  libportaudio2
  python-soundfile
  python-numpy
  python-pyaudio
)
```

The snips platform will need mosquitto, but other plugins too : but the uninstall script will remove it : it would be best to have each add-ons containerized or running in an isolated chroot , actually I would favor something like the `snap` packaging or to run everything in a single directory as done here -> https://github.com/createcandle/voco/tree/master/snips


